### PR TITLE
Preserve event paths in zip download

### DIFF
--- a/tests/test_wedding_app.py
+++ b/tests/test_wedding_app.py
@@ -75,5 +75,5 @@ def test_download_zip(monkeypatch):
     monkeypatch.setenv("AZURE_STORAGE_CONNECTION_STRING", "conn")
     buf = storage.download_files_as_zip("c", ["path/a.txt", "path/b.txt"])
     z = zipfile.ZipFile(buf)
-    assert set(z.namelist()) == {"a.txt", "b.txt"}
+    assert set(z.namelist()) == {"path/a.txt", "path/b.txt"}
 

--- a/wedding_app/storage.py
+++ b/wedding_app/storage.py
@@ -46,7 +46,7 @@ def download_files_as_zip(container: str, files: Iterable[str]) -> io.BytesIO:
         for name in files:
             blob = service.get_blob_client(container=container, blob=name)
             data = blob.download_blob().readall()
-            zf.writestr(os.path.basename(name), data)
+            zf.writestr(name, data)
     buf.seek(0)
     return buf
 


### PR DESCRIPTION
## Summary
- keep subevent folder structure when downloading multiple files as zip
- update tests accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868184d0724832cb2c2ac2f5a4408ae